### PR TITLE
Unused fields

### DIFF
--- a/henry/.support_files/help.rtf
+++ b/henry/.support_files/help.rtf
@@ -23,9 +23,9 @@
 
 
 \033[1;4mAvailable Commands\033[0m
-pulse                                      Runs diagnostic tests to check the overall health of your Looker instance
-analyze [projects | models | explores]     Analyses projects, models and explores to help identify model bloat
-vacuum  [models | explores]                Identifies and outputs a list of unused content in models and explores
+pulse                                               Runs diagnostic tests to check the overall health of your Looker instance
+analyze [projects | models | explores | fields]     Analyses projects, models, explores and fields to help identify model bloat
+vacuum  [models | explores | fields]                Identifies and outputs a list of unused content in models, explores and fields
 
 \033[1;4mGlobal Options\033[0m
   \033[1m--host\033[0m \033[4mhost\033[0m                              Looker host in the form of hostname.looker.com

--- a/henry/cli.py
+++ b/henry/cli.py
@@ -86,6 +86,7 @@ def main():
     analyze_projects = analyze_subparsers.add_parser('projects')
     analyze_models = analyze_subparsers.add_parser('models')
     analyze_explores = analyze_subparsers.add_parser('explores')
+    analyze_fields = analyze_subparsers.add_parser('fields')
 
     # project subcommand
     analyze_projects.set_defaults(which='projects')
@@ -164,6 +165,35 @@ def main():
                                   nargs=1,
                                   help='Limit results. No limit by default')
 
+    # fields subcommand
+    analyze_fields.set_defaults(which='fields')
+    analyze_fields.add_argument('-model', '--model',
+                                  type=str,
+                                  default=None,
+                                  required=('--explore') in sys.argv,
+                                  help='Filter on model')
+    analyze_fields.add_argument('-e', '--explore',
+                                  default=None,
+                                  help='Filter on model')
+    analyze_fields.add_argument('--timeframe',
+                                  type=int,
+                                  default=90,
+                                  help='Timeframe (between 0 and 90)')
+    analyze_fields.add_argument('--min_queries',
+                                  type=int,
+                                  default=0,
+                                  help='Query threshold')
+    analyze_fields.add_argument('--order_by',
+                                  nargs=2,
+                                  metavar=('ORDER_FIELD', 'ASC/DESC'),
+                                  dest='sortkey',
+                                  help='Sort results by a field')
+    analyze_fields.add_argument('--limit',
+                                  type=int,
+                                  default=None,
+                                  nargs=1,
+                                  help='Limit results. No limit by default')
+
     # VACUUM Subcommand
     vacuum_parser = subparsers.add_parser('vacuum', help='vacuum help',
                                           usage='henry vacuum')
@@ -171,6 +201,7 @@ def main():
     vacuum_subparsers = vacuum_parser.add_subparsers()
     vacuum_models = vacuum_subparsers.add_parser('models')
     vacuum_explores = vacuum_subparsers.add_parser('explores')
+    vacuum_fields = vacuum_subparsers.add_parser('fields')
     vacuum_models.set_defaults(which='models')
     vm_group = vacuum_models.add_mutually_exclusive_group()
     vm_group.add_argument('-p', '--project',
@@ -217,8 +248,29 @@ def main():
                                  default=0,
                                  help='Query threshold')
 
-    for subparser in [analyze_projects, analyze_models, analyze_explores,
-                      vacuum_models, vacuum_explores, pulse]:
+    vacuum_fields.set_defaults(which='fields')
+    vacuum_fields.add_argument('-m', '--model',
+                                 type=str,
+                                 default=None,
+                                 required=('--explore') in sys.argv,
+                                 help='Filter on model')
+
+    vacuum_fields.add_argument('-e', '--explore',
+                                 type=str,
+                                 default=None,
+                                 help='Filter on explore')
+
+    vacuum_fields.add_argument('--timeframe',
+                                 type=int,
+                                 default=90,
+                                 help='Timeframe (between 0 and 90)')
+
+    vacuum_fields.add_argument('--min_queries',
+                                 type=int,
+                                 default=0,
+                                 help='Query threshold')
+    for subparser in [analyze_projects, analyze_models, analyze_explores, analyze_fields,
+                      vacuum_models, vacuum_explores, vacuum_fields, pulse]:
         subparser.add_argument('--output',
                                type=str,
                                default=None,

--- a/henry/commands/analyze.py
+++ b/henry/commands/analyze.py
@@ -207,7 +207,7 @@ class Analyze(fetcher):
         total = len(explores)
         completed = 1
         for e in explores:
-            print('Analyzing {}, {} of {} explores'.format(e,
+            print('Analyzing {}, {} of {} explores'.format(e['name'],
                                                         completed,
                                                         total))
             # in case explore does not exist (bug - #32748)

--- a/henry/commands/analyze.py
+++ b/henry/commands/analyze.py
@@ -51,6 +51,20 @@ class Analyze(fetcher):
                                             limit=kwargs['limit'],
                                             timeframe=kwargs['timeframe'],
                                             min_queries=kwargs['min_queries'])
+        elif kwargs['which'] == 'fields':
+            params = {k: kwargs[k] for k in {'model',
+                                             'explore',
+                                             'timeframe',
+                                             'min_queries',
+                                             'sortkey',
+                                             'limit'}}
+            self.analyze_logger.info('analyze fields params=%s', )
+            result = self._analyze_fields(model=m,
+                                            explore=kwargs['explore'],
+                                            sortkey=kwargs['sortkey'],
+                                            limit=kwargs['limit'],
+                                            timeframe=kwargs['timeframe'],
+                                            min_queries=kwargs['min_queries'])
         self.analyze_logger.info('Analyze Complete')
 
         result = tabulate(result, headers=headers,
@@ -122,6 +136,11 @@ class Analyze(fetcher):
         info = styler.limit(info, limit=limit)
         return info
 
+    def _analyze_fields(self, model=None, explore=None,
+                        sortkey=None, limit=None,
+                        min_queries=0, timeframe=90):
+        pass
+
     def _analyze_explores(self, model=None, explore=None,
                           sortkey=None, limit=None,
                           min_queries=0, timeframe=90):
@@ -132,10 +151,10 @@ class Analyze(fetcher):
         explores_usage = {}
         info = []
         total = len(explores)
-        completed = 0
+        completed = 1
         for e in explores:
-            print('Parsing {}, {} of {} explores'.format(completed,
-                                                        e['model_name'],
+            print('Analyzing {}, {} of {} explores'.format(e,
+                                                        completed,
                                                         total))
             # in case explore does not exist (bug - #32748)
             if e is None:

--- a/henry/commands/vacuum.py
+++ b/henry/commands/vacuum.py
@@ -65,6 +65,10 @@ class Vacuum(fetcher):
 
         return info
 
+    def _vacuum_fields(self, model=None, explore=None, timeframe=90,
+                        min_queries=0):
+        pass
+
     def _vacuum_explores(self, model=None, explore=None, timeframe=90,
                          min_queries=0):
         explores = fetcher.get_explores(self,

--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -181,7 +181,7 @@ class Fetcher(object):
                         "query.model": m,
                         "query.view": e,
                         "history.query_run_count": min_queries},
-            "limit": "50000"
+            "limit": "100000"
         }
         # returns only fields used from a given explore
         response = self.looker.run_inline_query("json", body)

--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -116,25 +116,31 @@ class Fetcher(object):
         return explores
 
     def get_explore_fields(self, explore=None, scoped_names=0):
-        self.fetch_logger.info('Parsing explore body for exposed fields')
+        self.fetch_logger.info('Parsing explore body for fields')
         fields = []
         for dimension in explore['fields']['dimensions']:
-            if dimension['hidden'] is not True:
-                fields.append((explore['model_name']+'.'
-                              + explore['name'] + '.')*scoped_names
-                              + dimension['name'])
+            # if dimension['hidden'] is not True:
+            fields.append((explore['model_name']+'.'
+                          + explore['name'] + '.')*scoped_names
+                          + dimension['name'])
         for measure in explore['fields']['measures']:
-            if measure['hidden'] is not True:
-                fields.append((explore['model_name']+'.'
-                              + explore['name']+'.')*scoped_names
-                              + measure['name'])
+            # if measure['hidden'] is not True:
+            fields.append((explore['model_name']+'.'
+                          + explore['name']+'.')*scoped_names
+                          + measure['name'])
         for fltr in explore['fields']['filters']:
-            if fltr['hidden'] is not True:
-                fields.append((explore['model_name']+'.'
-                              + explore['name']+'.')*scoped_names
-                              + fltr['name'])
+            # if fltr['hidden'] is not True:
+            fields.append((explore['model_name']+'.'
+                          + explore['name']+'.')*scoped_names
+                          + fltr['name'])
         self.fetch_logger.info('Parsing Complete')
         return list(set(fields))
+
+    def get_explore_field_stats(self, explore=None, scoped_names=0):
+        self.fetch_logger.info('Parsing explore body for fields')
+        fields = []
+        dim_count, measure_count, has_description = 0,0,0
+
 
     def get_unused_explores(self, model=None, timeframe=90, min_queries=0):
         self.fetch_logger.info('Fetching unused explores, %s', locals())

--- a/henry/modules/lookerapi.py
+++ b/henry/modules/lookerapi.py
@@ -116,7 +116,6 @@ class LookerApi(object):
                                                          'explores',
                                                          explore_name)
         params = fields
-        print(url)
         self.api_logger.info('Request to %s => GET /api/3.0/lookml_models/%s'
                              '/explores/%s, %s', self.host, model_name,
                              explore_name, params)


### PR DESCRIPTION
Two new commands have been incorporated into Henry:

- henry analyze fields
- henry vacuum fields

The analyze command will now tell you, by explore, the number of measures/dimensions the explore has, how many are missing descriptions, as well as a rough estimate on number of unused fields (more on why it’s an estimate in a second).

The vacuum command will now expose all unused fields within a defined timeframe (default 90). It’s ideal to not run this with an arguments for —models or —explores. Previously, Henry was exposing unused fields on an explore level in the vacuum explores command. However, these fields could be used in another explore since views are shared by explores. As a result, it was possible to try and remove an unused field and it would break another explore in content validation.

I’ve written this new command to aggregate fields across ALL explores before checking which ones go unused. It also checks SQL joins in models to see if a field is being used as a join field but not anywhere else (Henry was missing this before). It then returns a list of all unused fields (based on the user provided parameters) grouped by its view.