### PR TITLE
Fix unicode issue

### DIFF
--- a/henry/modules/fetcher.py
+++ b/henry/modules/fetcher.py
@@ -3,6 +3,11 @@ from . import styler
 from collections import Counter
 import logging
 import re
+import sys
+reload(sys)
+
+sys.setdefaultencoding('utf-8')
+
 
 
 class Fetcher(object):


### PR DESCRIPTION
Fixing a unicode issue via `import sys` and always setting unicode to utf-8